### PR TITLE
Add ability to disable automatic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ PESAPAL_SECRET=yourConsumerSecret
 PESAPAL_IS_LIVE=false
 PESAPAL_CALLBACK_URL=
 ```  
+## Migrations  
+
+If you are not going to use Pesapal default migrations, you should call the `PesapalConfig::ignoreMigrations` method in the register method of your `AppServiceProvider`. You may export the default migrations using 
+
+```bash
+php artisan vendor:publish --tag=pesapal-migrations.
+```
 
 Thereafter, run the migration command as the package will load a database migration that stores the payment records    
 

--- a/src/Pesapal.php
+++ b/src/Pesapal.php
@@ -49,13 +49,6 @@ class Pesapal
     private OAuthConsumer $consumer;
 
     /**
-     * Indicates if Pesapal migrations will be run.
-     *
-     * @var bool
-     */
-    public static $runsMigrations = true;
-
-    /**
      * Pesapal constructor.
      *
      * @param OAuthSignatureMethod_HMAC_SHA1 $signature
@@ -220,17 +213,5 @@ class Pesapal
 
         curl_close($ch);
         return $elements[1];
-    }
-
-    /**
-     * Configure Pesapal to not register its migrations.
-     *
-     * @return static
-     */
-    public static function ignoreMigrations()
-    {
-        static::$runsMigrations = false;
-
-        return new static;
     }
 }

--- a/src/Pesapal.php
+++ b/src/Pesapal.php
@@ -49,6 +49,13 @@ class Pesapal
     private OAuthConsumer $consumer;
 
     /**
+     * Indicates if Pesapal migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
      * Pesapal constructor.
      *
      * @param OAuthSignatureMethod_HMAC_SHA1 $signature
@@ -213,5 +220,17 @@ class Pesapal
 
         curl_close($ch);
         return $elements[1];
+    }
+
+    /**
+     * Configure Pesapal to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+
+        return new static;
     }
 }

--- a/src/PesapalConfig.php
+++ b/src/PesapalConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bryceandy\Laravel_Pesapal;
+
+class PesapalConfig
+{
+    /**
+     * Indicates if Pesapal migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
+     * Configure Pesapal to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+    }
+}

--- a/src/PesapalServiceProvider.php
+++ b/src/PesapalServiceProvider.php
@@ -23,6 +23,10 @@ class PesapalServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/config/pesapal.php' => config_path('pesapal.php'),
             ], 'pesapal-config');
+    
+            $this->publishes([
+                __DIR__.'/database/migrations' => database_path('migrations'),
+            ], 'pesapal-migrations');
         }
 
         // Load middleware alias
@@ -54,6 +58,9 @@ class PesapalServiceProvider extends ServiceProvider
 
         $this->loadRoutesFrom(__DIR__.'/routes/web.php');
         $this->loadViewsFrom(__DIR__.'/resources/views', 'laravel_pesapal');
-        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
+
+        if ($this->app->runningInConsole() && Pesapal::$runsMigrations) {
+            $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
+        }
     }
 }


### PR DESCRIPTION
This commit introduces the `ignoreMigrations` method in the `Bryceandy\Laravel_Pesapal\Pesapal`, allowing users to disable the automatic loading of migrations provided by the package.

<?php

namespace App\Providers;

use Bryceandy\\Laravel_Pesapal\Pesapal;

class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Pesapal::ignoreMigrations();
    }
}`